### PR TITLE
Allow for using UniFi OS based devices

### DIFF
--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -75,7 +75,7 @@ namespace KoenZomers.UniFi.Api
         /// </summary>
         /// <param name="baseUri">BaseUri of the UniFi Controller, i.e. https://192.168.0.1:8443</param>
         /// <param name="siteId">Identifier of the site in UniFi. Set to NULL if you want to use the default site.</param>
-        /// <param name="isUniFiOS">Specifies if target controller is UnifiOS based device or stand-alone software controller</param>
+        /// <param name="isUniFiOS">Specifies if target controller is UniFi OS based device or stand-alone software controller</param>
         public Api(Uri baseUri, string siteId, bool isUniFiOS = false)
         {
             BaseUri = baseUri;

--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -47,4 +47,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.12.2" />
+  </ItemGroup>
 </Project>

--- a/Api/KoenZomers.UniFi.Api.xml
+++ b/Api/KoenZomers.UniFi.Api.xml
@@ -44,18 +44,24 @@
             Boolean indicating whether this Api session is authenticated
             </summary>
         </member>
+        <member name="P:KoenZomers.UniFi.Api.Api.IsUniFiOS">
+            <summary>
+            Boolean indicating whether UniFi Controller is Unifi OS
+            </summary>
+        </member>
         <member name="M:KoenZomers.UniFi.Api.Api.#ctor(System.Uri)">
             <summary>
             Instantiates a new instance of the UniFi API Controller class against the default UniFi site
             </summary>
             <param name="baseUri">BaseUri of the UniFi Controller, i.e. https://192.168.0.1:8443</param>
         </member>
-        <member name="M:KoenZomers.UniFi.Api.Api.#ctor(System.Uri,System.String)">
+        <member name="M:KoenZomers.UniFi.Api.Api.#ctor(System.Uri,System.String,System.Boolean)">
             <summary>
             Instantiates a new instance of the UniFi API Controller class
             </summary>
             <param name="baseUri">BaseUri of the UniFi Controller, i.e. https://192.168.0.1:8443</param>
             <param name="siteId">Identifier of the site in UniFi. Set to NULL if you want to use the default site.</param>
+            <param name="isUniFiOS">Specifies if target controller is UnifiOS based device or stand-alone software controller</param>
         </member>
         <member name="M:KoenZomers.UniFi.Api.Api.DisableSslValidation">
             <summary>
@@ -274,7 +280,7 @@
             <param name="timeout">Timeout in milliseconds on how long the request may take. Default = 60000 = 60 seconds.</param>
             <returns>The website contents returned by the webserver after posting the data</returns>
         </member>
-        <member name="M:KoenZomers.UniFi.Api.HttpUtility.LogoutViaJsonPostMethod(System.Uri,System.Net.CookieContainer,System.Int32)">
+        <member name="M:KoenZomers.UniFi.Api.HttpUtility.LogoutViaJsonPostMethod(System.Uri,System.Net.CookieContainer,System.Int32,System.Boolean)">
             <summary>
             Sends a POST request to log out from the UniFi Controller
             </summary>
@@ -597,6 +603,26 @@
         <member name="P:KoenZomers.UniFi.Api.Responses.Device.Id">
             <summary>
             Unique device ID
+            </summary>
+        </member>
+        <member name="T:KoenZomers.UniFi.Api.Responses.LoginResponse">
+            <summary>
+            Basic stub of login response to use to see if deserialization was successful or not
+            </summary>
+        </member>
+        <member name="P:KoenZomers.UniFi.Api.Responses.LoginResponse.Unique_Id">
+            <summary>
+            Unique id of logged in user
+            </summary>
+        </member>
+        <member name="T:KoenZomers.UniFi.Api.Responses.LogoutResponse">
+            <summary>
+            Response status of logout against UniFi OS based Controller
+            </summary>
+        </member>
+        <member name="P:KoenZomers.UniFi.Api.Responses.LogoutResponse.Success">
+            <summary>
+            Notes if logout was successful or not
             </summary>
         </member>
         <member name="T:KoenZomers.UniFi.Api.Responses.Meta">

--- a/Api/Responses/LoginResponse.cs
+++ b/Api/Responses/LoginResponse.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace KoenZomers.UniFi.Api.Responses
+{
+    /// <summary>
+    /// Basic stub of login response to use to see if deserialization was successful or not
+    /// </summary>
+    public class LoginResponse
+    {
+        /// <summary>
+        /// Unique id of logged in user
+        /// </summary>
+        public string Unique_Id { get; set; }
+    }
+}

--- a/Api/Responses/LogoutResponse.cs
+++ b/Api/Responses/LogoutResponse.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace KoenZomers.UniFi.Api.Responses
+{
+    /// <summary>
+    /// Response status of logout against UniFi OS based Controller
+    /// </summary>
+    public class LogoutResponse
+    {
+        /// <summary>
+        /// Notes if logout was successful or not
+        /// </summary>
+        public bool Success{ get; set; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ API in C# which can be used to read data from an on premises UniFi Controller in
 
 It is sufficient to use an account with the "Read Only" role in UniFi unless you want to modify things like using BlockClient, UnblockClient, AuthorizeGuest or UnauthorizeGuest.
 
-This API works with hosting UniFi yourself on a Windows or Linux based operating system. It will not work when using UnifiOS.
+This API now works with hosting UniFi yourself on a Windows or Linux based operating system, as well Unifi OS devices such as the Cloud Key Gen2 Plus.
 
 ## Usage
 


### PR DESCRIPTION
Based on information at https://ubntwiki.com/products/software/unifi-controller/start and my own testing, there appear to be a few minor differences between the APIs between the Windows/Linux run UniFi Controller and that on a UniFi OS based device

These changes include a couple of quirks as to how login/logoff work, as well as a slightly URL to hit APIs.

This PR introduces a way to be able to select which kind of controller will be connected to and adjust calls accordingly.

This has been tested against both an empty UniFi Controller running in a Windows virtual machine, as well as my Cloud Key Gen2 Plus (the only physical UFOS device I have access to).